### PR TITLE
Fix mobile view issue

### DIFF
--- a/src/components/Footer/footer.scss
+++ b/src/components/Footer/footer.scss
@@ -59,3 +59,21 @@ footer {
     display: none;
   }
 }
+
+
+@media screen and (max-width: 500px) {
+
+  .footer-left-info {
+    font-size: 10px;
+    text-decoration: none;
+    margin-left: 5px !important;
+    
+    a.icon {
+      margin: 0px !important;
+      svg {
+        width: 25px !important;
+        height: 25px !important;
+      }
+    }
+}
+}

--- a/src/components/Footer/footer.scss
+++ b/src/components/Footer/footer.scss
@@ -60,14 +60,12 @@ footer {
   }
 }
 
-
 @media screen and (max-width: 500px) {
-
   .footer-left-info {
     font-size: 10px;
     text-decoration: none;
     margin-left: 5px !important;
-    
+
     a.icon {
       margin: 0px !important;
       svg {
@@ -75,5 +73,5 @@ footer {
         height: 25px !important;
       }
     }
-}
+  }
 }

--- a/src/components/GraphData/graph-data.scss
+++ b/src/components/GraphData/graph-data.scss
@@ -118,7 +118,7 @@
 
         svg {
           color: var(--iconColour);
-          height: 24px;
+          height: 25px;
         }
       }
     }
@@ -222,6 +222,6 @@
     margin-bottom: -5px;
   }
   .theme-icon {
-    margin-bottom: -5px;
+    margin-bottom: -8px;
   }
 }

--- a/src/components/GraphData/graph-data.tsx
+++ b/src/components/GraphData/graph-data.tsx
@@ -202,21 +202,21 @@ const GraphData: React.FunctionComponent<RouteComponentProps<any>> = ({ location
               >
                 {theme === label.LIGHT_THEME_LABEL ? (
                   <a href={Constants.ROUTES.HOME_ROUTE}>
-                <img
-                  src="/images/GraphLooker_theme_color_text.png"
-                  height="50px"
-                  alt="GraphLooker-icon"
-                ></img>
-                </a>
-              ) : (
-                <a href={Constants.ROUTES.HOME_ROUTE}>
-                <img
-                  src="/images/GraphLooker_white_text.png"
-                  height="50px"
-                  alt="GraphLooker-icon"
-                ></img>
-                </a>
-              )}
+                    <img
+                      src="/images/GraphLooker_theme_color_text.png"
+                      height="50px"
+                      alt="GraphLooker-icon"
+                    ></img>
+                  </a>
+                ) : (
+                  <a href={Constants.ROUTES.HOME_ROUTE}>
+                    <img
+                      src="/images/GraphLooker_white_text.png"
+                      height="50px"
+                      alt="GraphLooker-icon"
+                    ></img>
+                  </a>
+                )}
               </Box>
 
               {drawerOpen ? (
@@ -299,21 +299,21 @@ const GraphData: React.FunctionComponent<RouteComponentProps<any>> = ({ location
               <Box>
                 {theme === label.LIGHT_THEME_LABEL ? (
                   <a href={Constants.ROUTES.HOME_ROUTE}>
-                <img
-                  src="/images/GraphLooker_theme_color_text.png"
-                  height="50px"
-                  alt="GraphLooker-icon"
-                ></img>
-                </a>
-              ) : (
-                <a href={Constants.ROUTES.HOME_ROUTE}>
-                <img
-                  src="/images/GraphLooker_white_text.png"
-                  height="50px"
-                  alt="GraphLooker-icon"
-                ></img>
-                </a>
-              )}
+                    <img
+                      src="/images/GraphLooker_theme_color_text.png"
+                      height="50px"
+                      alt="GraphLooker-icon"
+                    ></img>
+                  </a>
+                ) : (
+                  <a href={Constants.ROUTES.HOME_ROUTE}>
+                    <img
+                      src="/images/GraphLooker_white_text.png"
+                      height="50px"
+                      alt="GraphLooker-icon"
+                    ></img>
+                  </a>
+                )}
               </Box>
             </DrawerHeader>
             {drawer}

--- a/src/components/GraphData/graph-data.tsx
+++ b/src/components/GraphData/graph-data.tsx
@@ -200,13 +200,23 @@ const GraphData: React.FunctionComponent<RouteComponentProps<any>> = ({ location
                   display: { xs: 'none', sm: 'block' },
                 }}
               >
-                <a href={Constants.ROUTES.HOME_ROUTE}>
-                  <img
-                    src="/images/GraphLooker_white_text.png"
-                    height="50px"
-                    alt="GraphLooker-icon"
-                  ></img>
+                {theme === label.LIGHT_THEME_LABEL ? (
+                  <a href={Constants.ROUTES.HOME_ROUTE}>
+                <img
+                  src="/images/GraphLooker_theme_color_text.png"
+                  height="50px"
+                  alt="GraphLooker-icon"
+                ></img>
                 </a>
+              ) : (
+                <a href={Constants.ROUTES.HOME_ROUTE}>
+                <img
+                  src="/images/GraphLooker_white_text.png"
+                  height="50px"
+                  alt="GraphLooker-icon"
+                ></img>
+                </a>
+              )}
               </Box>
 
               {drawerOpen ? (
@@ -280,20 +290,30 @@ const GraphData: React.FunctionComponent<RouteComponentProps<any>> = ({ location
                 boxSizing: 'border-box',
                 width: drawerWidth,
                 backgroundColor: `${theme === label.LIGHT_THEME_LABEL ? label.WHITE : label.BLACK}`,
-                color: 'white',
+                color: '#757474',
                 paddingBottom: '8rem',
               },
             }}
           >
             <DrawerHeader>
               <Box>
-                <a href={Constants.ROUTES.HOME_ROUTE}>
-                  <img
-                    src="/images/GraphLooker_theme_color_text.png"
-                    height="33px"
-                    alt="GraphLooker-icon"
-                  ></img>
+                {theme === label.LIGHT_THEME_LABEL ? (
+                  <a href={Constants.ROUTES.HOME_ROUTE}>
+                <img
+                  src="/images/GraphLooker_theme_color_text.png"
+                  height="50px"
+                  alt="GraphLooker-icon"
+                ></img>
                 </a>
+              ) : (
+                <a href={Constants.ROUTES.HOME_ROUTE}>
+                <img
+                  src="/images/GraphLooker_white_text.png"
+                  height="50px"
+                  alt="GraphLooker-icon"
+                ></img>
+                </a>
+              )}
               </Box>
             </DrawerHeader>
             {drawer}


### PR DESCRIPTION
->  made graphlooker icon dynamic in both app drawer component and the graph data file
IPHONE SE:-
![image](https://user-images.githubusercontent.com/91467774/183355590-3e054608-4b33-4305-9094-bae97208898c.png)
![image](https://user-images.githubusercontent.com/91467774/183355659-07e208c6-3700-4dbe-9744-4e76454d0e23.png)


-> aligned graphlooker theme icon perfectly.

-> fixed backed by statement in footer :-
![image](https://user-images.githubusercontent.com/91467774/183365149-7fb1ec8e-c9e2-4b10-ac7e-83571dcfae5e.png)
